### PR TITLE
Fix dispose on logout, and logout fix

### DIFF
--- a/Skymu/App.xaml.cs
+++ b/Skymu/App.xaml.cs
@@ -324,7 +324,10 @@ namespace Skymu
             } // Sends close to the websocket while the app is dying around it. This only works cos of the delay caused by the logout sound.
             catch { } // If it doesn't work, too bad.
             if (HasLoggedIn)
+            {
+                Plugins.DisposeAll();
                 Sounds.PlaySynchronous("logout");
+            }
             base.OnExit(ev);
         }
     }

--- a/Skymu/ViewModels/LoginViewModel.cs
+++ b/Skymu/ViewModels/LoginViewModel.cs
@@ -142,6 +142,7 @@ namespace Skymu.ViewModels
         public void HandleProtocolSelected(PluginListing listing)
         {
             if (listing == null) return;
+            if (PendingAutoLogin != null) return;
             _selectedListing = listing;
             Universal.Plugin = Universal.PluginList[listing.PluginIndex];
             PluginSelectionUpdated?.Invoke(listing);


### PR DESCRIPTION
1. PendingAutoLogin exist = do NOT do HandleProtocolSelected (hacky, could have some consequences)
- This fixes a case where logout immediately throws you to auto login.
- Also, most importantly, this now lets Dispose to be called. Before, Stub plugin's dispose was called, in an environment where only Stub and Tox were compiled. This could've been very messy depending on plugins being missing, or have some new stuff...
2. DisposeAll before app close
- Dispose is now called on exit. Useful for Tox, and other protocols that expects for `yes im exiting` event.