### PR TITLE
Fix the text + home icon overlap

### DIFF
--- a/Skymu/Skyaeris/Main.xaml
+++ b/Skymu/Skyaeris/Main.xaml
@@ -994,6 +994,7 @@
                                         TextColor="#FFFFFF"
                                         TextFont="Arial"
                                         TextLeftMargin="43"
+                                        TextRightMargin="30"
                                         TextSize="13"
                                         TextWeight="Bold" />
                                     <StackPanel


### PR DESCRIPTION
I have hopped on an offline session, to try to make this as accurate as possible. 30 seemed best to me.

Broken version would look like this:

<img width="389" height="159" alt="image" src="https://github.com/user-attachments/assets/58715f40-cbd4-43a8-94ce-18a015adf991" />
