### PR TITLE
Fix crash on SeanKype caused by fetching the avatar image in a very incorrect way

### DIFF
--- a/Skymu/SeanKype/Main.xaml.cs
+++ b/Skymu/SeanKype/Main.xaml.cs
@@ -408,9 +408,8 @@ namespace Skymu.SeanKype
 
         private BitmapImage GenerateAvatarImage(string avatar)
         {
-            string avatarPath =
-                "Pontis/Profile Pictures/" + avatar + ".png";
-            return FrozenImage.Generate(avatarPath);
+            string AvatarPath = Converters.Helpers.GetAssetBasePrefix("SeanKype") + "Profile Pictures/" + avatar + ".png";
+            return FrozenImage.Generate(AvatarPath);
         }
 
         #endregion


### PR DESCRIPTION
Previously, it was `"Pontis/Profile Pictures/" + avatar + ".png"`. Pontis/Assets/ is the right way. I copied the code from Skyaeris for this.