### PR TITLE
Add the General -> Main settings window

### DIFF
--- a/Skymu/Forms/Options.xaml.cs
+++ b/Skymu/Forms/Options.xaml.cs
@@ -51,6 +51,7 @@ namespace Skymu.Forms
             {
                 { General_Skymu, () => new OptionPages.General.Skymu() },
                 { Advanced_Debug, () => new OptionPages.Advanced.Debug() },
+                { General_Main, () => new OptionPages.General.Main() }
             };
             tabToText = new Dictionary<SliceControl, string>
             {

--- a/Skymu/Forms/Options/General/Main.xaml
+++ b/Skymu/Forms/Options/General/Main.xaml
@@ -1,0 +1,105 @@
+﻿<!--
+    ============================================================
+    Copyright © The Skymu Team and other contributors.
+    For any inquiries or concerns, email contact@skymu.app.
+    ============================================================
+    Modification or redistribution of this code is governed
+    by the terms set out in the project license agreement.
+    If you do not comply with those terms, you may not
+    modify or distribute any original code from the project.
+    ============================================================
+    License: https://skymu.app/legal/license
+    SPDX-License-Identifier: AGPL-3.0-or-later
+    ============================================================
+-->
+<Page
+    x:Class="Skymu.Forms.OptionPages.General.Main"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:converters="clr-namespace:Skymu.Converters"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:global="clr-namespace:Skymu"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:preferences="clr-namespace:Skymu.Preferences"
+    xmlns:theming="clr-namespace:Skymu.Theming"
+    HorizontalAlignment="Stretch"
+    VerticalAlignment="Stretch"
+    d:Background="#FFFFFF"
+    d:Height="505"
+    d:Width="514"
+    DataContext="{StaticResource Lang}"
+    FontFamily="Tahoma"
+    FontSize="11"
+    Foreground="{DynamicResource Text.VeryHighContrast}"
+    Style="{StaticResource Page}"
+    mc:Ignorable="d">
+
+    <ScrollViewer Margin="10">
+        <StackPanel Orientation="Vertical">
+
+            <StackPanel Margin="0,5" Orientation="Horizontal">
+                <CheckBox
+Margin="0,5"
+Padding="6, 0"
+Content="{Binding [sF_OPTIONS_LB_1]}"
+Foreground="{DynamicResource Text.VeryHighContrast}"
+IsChecked="False"
+IsEnabled="False"/>
+            </StackPanel>
+
+            <Separator Margin="2,2,5,2" Foreground="{DynamicResource Separator}" />
+
+            <StackPanel Margin="0,5" Orientation="Horizontal">
+                <CheckBox
+Margin="0,5"
+Padding="6, 0"
+Content="{Binding [sF_OPTIONS_LB_2]}"
+Foreground="{DynamicResource Text.VeryHighContrast}"
+IsChecked="False"
+IsEnabled="False"/>
+            </StackPanel>
+
+            <Separator Margin="2,2,5,2" Foreground="{DynamicResource Separator}" />
+
+            <StackPanel Margin="0,5" Orientation="Horizontal">
+                <CheckBox
+Margin="0,5"
+Padding="6, 0"
+Content="{Binding [sF_USERENTRY_CB_START_SKYPE]}"
+Foreground="{DynamicResource Text.VeryHighContrast}"
+IsChecked="{Binding Path=[AutoLaunch], Mode=TwoWay, Source={x:Static preferences:Settings.Default}}" />
+            </StackPanel>
+
+            <Separator Margin="2,2,5,2" Foreground="{DynamicResource Separator}" />
+
+
+            <StackPanel Margin="0,5" Orientation="Horizontal">
+                <TextBlock
+                    Padding="0,0,10,0"
+                    VerticalAlignment="Center"
+                    Text="{Binding [sF_USERINFO_LABEL_LANGUAGE]}" />
+                            <ComboBox
+                    Width="250"
+                    DisplayMemberPath="Key"
+                    ItemsSource="{Binding Languages}"
+                    SelectedValue="{Binding Path=[Language], Mode=TwoWay, Source={x:Static preferences:Settings.Default}}"
+                    SelectedValuePath="Key"
+                                SelectionChanged="OnLanguageSelectionChanged"/>
+            </StackPanel>
+
+            <Separator Margin="2,2,5,2" Foreground="{DynamicResource Separator}" />
+
+            <StackPanel Margin="0,5" Orientation="Horizontal">
+                <CheckBox
+Margin="0,5"
+Padding="6, 0"
+Content="{Binding [sOPTIONS_DISPLAY_AVATARS]}"
+Foreground="{DynamicResource Text.VeryHighContrast}"
+IsChecked="False"
+IsEnabled="False"/>
+            </StackPanel>
+
+
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/Skymu/Forms/Options/General/Main.xaml.cs
+++ b/Skymu/Forms/Options/General/Main.xaml.cs
@@ -1,0 +1,57 @@
+﻿/*==========================================================*/
+// Copyright © The Skymu Team and other contributors.
+// For any inquiries or concerns, email contact@skymu.app.
+/*==========================================================*/
+// Modification or redistribution of this code is governed
+// by the terms set out in the project license agreement.
+// If you do not comply with those terms, you may not
+// modify or distribute any original code from the project.
+/*==========================================================*/
+// License: https://skymu.app/legal/license
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/*==========================================================*/
+
+using System.Diagnostics;
+using System.Windows;
+using System.Windows.Controls;
+using Yggdrasil;
+
+namespace Skymu.Forms.OptionPages.General
+{
+    public partial class Main : Page
+    {
+        public Main()
+        {
+            InitializeComponent();
+        }
+
+        private void OnLanguageSelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            ComboBox comboBox = (ComboBox)sender;
+
+            // Prevent accidental triggers on window loading
+            if (comboBox == null || !comboBox.IsLoaded)
+                return;
+
+            Dialog dialog = new Dialog(
+                                    type: WindowBase.IconType.Question,
+                                    content: "Changing this option requires restarting Skymu to apply properly.",
+                                    header: "Would you like to restart Skymu?",
+                                    brText: "No",
+                                    blEnabled: true,
+                                    blText: "Yes"
+                                );
+            dialog.BRAction = () =>
+            {
+                dialog.Close();
+            };
+            dialog.BLAction = () =>
+            {
+                dialog.Close();
+                Process.Start(Process.GetCurrentProcess().MainModule.FileName);
+                Application.Current.Shutdown();
+            };
+            dialog.ShowDialog();
+        }
+    }
+}


### PR DESCRIPTION
Looks pretty much the real Skype's. Options that don't exist in Skymu (but are kept to keep the UI accurate) are greyed out. Other options work the same.

Also I noticed that some forms (i.e. login window) wouldn't change language instantly, so changing language now prompts a choice to restart or to not. This can be removed in future, when it'll be fixed.

Preview:
<img width="702" height="605" alt="image" src="https://github.com/user-attachments/assets/1f4aa773-f8bc-4fa9-b89a-f805a3cb4224" />
