### PR TITLE
Make Skype 6 theme Options window look more like Skype 6

### DIFF
--- a/Skymu.sln
+++ b/Skymu.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.36631.11
+# Visual Studio Version 17
+VisualStudioVersion = 17.14.37314.3 d17.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Skymu", "Skymu\Skymu.csproj", "{29B19002-44DC-4AB8-9BD7-135FC9D418A4}"
 EndProject

--- a/Skymu.sln
+++ b/Skymu.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.14.37314.3 d17.14
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.36631.11
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Skymu", "Skymu\Skymu.csproj", "{29B19002-44DC-4AB8-9BD7-135FC9D418A4}"
 EndProject

--- a/Skymu/App.xaml.cs
+++ b/Skymu/App.xaml.cs
@@ -40,6 +40,8 @@ using Yggdrasil.Enumerations;
 using Yggdrasil.Bottles;
 using OmegaAOL.Bifrost.Http;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Windows.Media;
 
 namespace Skymu
 {
@@ -284,6 +286,11 @@ namespace Skymu
                 case "Skype7":
                     return new Skype7.Login(switchUser, addAccount, accountAdded);
                 case "Skype6":
+                    // TODO: Make a better fix
+                    // Override Settings.ActiveTab on default colorway with the proper color (#0095cc)
+                    Application.Current.Resources["Settings.ActiveTab"] = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#0095cc"));
+                    // Override Settings.ActiveTabText to white
+                    Application.Current.Resources["Settings.ActiveTabText"] = new SolidColorBrush(Colors.White);
                     return new Skype6.Login(switchUser, addAccount, accountAdded);
                 case "Skype4":
                     return new Skype4.Login(switchUser, addAccount, accountAdded);

--- a/Skymu/Colorways/default.xaml
+++ b/Skymu/Colorways/default.xaml
@@ -104,6 +104,7 @@
     <SolidColorBrush x:Key="EmojiFlyout.Border" Color="#666666" />
 
     <SolidColorBrush x:Key="Settings.ActiveTab" Color="#85c0fc" />
+    <SolidColorBrush x:Key="Settings.ActiveTabText" Color="#666666" />
 
     <LinearGradientBrush x:Key="Strip.Background" StartPoint="0,0" EndPoint="0,1">
         <GradientStop Offset="0" Color="#F2F2F2" />

--- a/Skymu/Colorways/discord.xaml
+++ b/Skymu/Colorways/discord.xaml
@@ -99,6 +99,7 @@
 
     <!--  TODO  -->
     <SolidColorBrush x:Key="Settings.ActiveTab" Color="#85c0fc" />
+    <SolidColorBrush x:Key="Settings.ActiveTabText" Color="#FFB9BBBE" />
 
     <LinearGradientBrush x:Key="Strip.Background" StartPoint="0,0" EndPoint="0,1">
         <GradientStop Offset="0" Color="#33343b" />

--- a/Skymu/Colorways/newdiscord.xaml
+++ b/Skymu/Colorways/newdiscord.xaml
@@ -100,6 +100,7 @@
 
     <!--  TODO  -->
     <SolidColorBrush x:Key="Settings.ActiveTab" Color="#85c0fc" />
+    <SolidColorBrush x:Key="Settings.ActiveTabText" Color="#FFB5BAC1" />
 
     <LinearGradientBrush x:Key="Strip.Background" StartPoint="0,0" EndPoint="0,1">
         <GradientStop Offset="0" Color="#33343b" />

--- a/Skymu/Colorways/pink.xaml
+++ b/Skymu/Colorways/pink.xaml
@@ -97,6 +97,7 @@
     <SolidColorBrush x:Key="EmojiFlyout.Border" Color="#666666" />
 
     <SolidColorBrush x:Key="Settings.ActiveTab" Color="#FF44AA" />
+    <SolidColorBrush x:Key="Settings.ActiveTabText" Color="#666666" />
 
     <LinearGradientBrush x:Key="Strip.Background" StartPoint="0,0" EndPoint="0,1">
         <GradientStop Offset="0" Color="#F2F2F2" />

--- a/Skymu/Colorways/purple.xaml
+++ b/Skymu/Colorways/purple.xaml
@@ -85,6 +85,7 @@
     <SolidColorBrush x:Key="EmojiFlyout.Border" Color="#666666" />
 
     <SolidColorBrush x:Key="Settings.ActiveTab" Color="#ad77c6" />
+    <SolidColorBrush x:Key="Settings.ActiveTabText" Color="#666666" />
 
     <LinearGradientBrush x:Key="Strip.Background" StartPoint="0,0" EndPoint="0,1">
         <GradientStop Offset="0" Color="#F2F2F2" />

--- a/Skymu/Colorways/red.xaml
+++ b/Skymu/Colorways/red.xaml
@@ -100,6 +100,7 @@
 
     <!--  TODO  -->
     <SolidColorBrush x:Key="Settings.ActiveTab" Color="#85c0fc" />
+    <SolidColorBrush x:Key="Settings.ActiveTabText" Color="#666666" />
 
     <LinearGradientBrush x:Key="Strip.Background" StartPoint="0,0" EndPoint="0,1">
         <GradientStop Offset="0" Color="#F2F2F2" />

--- a/Skymu/Colorways/uwpdark.xaml
+++ b/Skymu/Colorways/uwpdark.xaml
@@ -95,6 +95,7 @@
     <SolidColorBrush x:Key="EmojiFlyout.Border" Color="#FF002D3E" />
 
     <SolidColorBrush x:Key="Settings.ActiveTab" Color="#FF00AFF0" />
+    <SolidColorBrush x:Key="Settings.ActiveTabText" Color="#FF899299" />
 
     <LinearGradientBrush x:Key="Strip.Background" StartPoint="0,0" EndPoint="0,1">
         <GradientStop Offset="0" Color="#FF021E2E" />

--- a/Skymu/Forms/Options.xaml
+++ b/Skymu/Forms/Options.xaml
@@ -103,6 +103,7 @@
                                 Tag="{Binding RelativeSource={RelativeSource AncestorType=global:SliceControl}}"
                                 Text="{TemplateBinding Text}"
                                 TextColor="{DynamicResource Text.MediumContrast}"
+                                TextColorPressed="{DynamicResource Settings.ActiveTabText}"
                                 TextFont="Tahoma"
                                 TextLeftMargin="39"
                                 TextSize="11" />

--- a/Skymu/UserControls/SliceControl.xaml.cs
+++ b/Skymu/UserControls/SliceControl.xaml.cs
@@ -44,6 +44,7 @@ namespace Skymu
     {
         #region Constructor
         private Brush _background;
+        private Brush _textColor;
         private ButtonVisualState _visualState = ButtonVisualState.Default;
         private static DispatcherTimer _sharedAnimationTimer;
         private static HashSet<SliceControl> _animatingControls = new HashSet<SliceControl>();
@@ -77,6 +78,7 @@ namespace Skymu
             InitializeComponent();
             Universal.ThemeChanged += OnThemeChanged;
             _background = Background;
+            _textColor = TextColor;
             _overlayRects = new[] { OverlayLeft, OverlayMiddle, OverlayRight };
 
             // Animation timer
@@ -252,6 +254,19 @@ namespace Skymu
         public static readonly DependencyProperty BackgroundPressedProperty =
             DependencyProperty.Register(
                nameof(BackgroundPressed),
+               typeof(Brush),
+               typeof(SliceControl),
+               new PropertyMetadata(null, OnAnyPropertyChanged)
+           );
+
+        public Brush TextColorPressed
+        {
+            get { return (Brush)GetValue(TextColorPressedProperty); }
+            set { SetValue(TextColorPressedProperty, value); }
+        }
+        public static readonly DependencyProperty TextColorPressedProperty =
+            DependencyProperty.Register(
+               nameof(TextColorPressed),
                typeof(Brush),
                typeof(SliceControl),
                new PropertyMetadata(null, OnAnyPropertyChanged)
@@ -990,6 +1005,7 @@ namespace Skymu
             UpdateTextOffset();
             UpdateIconOffset();
             UpdateBackground();
+            UpdateTextColor();
         }
 
         public ButtonVisualState GetState()
@@ -1036,6 +1052,26 @@ namespace Skymu
                 case ButtonVisualState.Pressed:
                     if (BackgroundPressed != null)
                         Background = BackgroundPressed;
+                    break;
+                    // TODO: Disabled
+            }
+        }
+
+        private void UpdateTextColor()
+        {
+            switch (_visualState)
+            {
+                case ButtonVisualState.Default:
+                    if (_textColor != null)
+                        TextColor = _textColor;
+                    break;
+                /*case ButtonVisualState.Hover:
+                    if (BackgroundHover != null)
+                        TextColor = BackgroundHover;
+                    break;*/
+                case ButtonVisualState.Pressed:
+                    if (TextColorPressed != null)
+                        TextColor = TextColorPressed;
                     break;
                     // TODO: Disabled
             }


### PR DESCRIPTION
<img width="712" height="610" alt="image" src="https://github.com/user-attachments/assets/f69996cb-c56b-493d-85d6-ff20efdc000f" />

Make Options window look more like Skype 6 in Skype 6 theme.

Changed active tab background to blue and active tab foreground to white (this required modifying SliceControl a bit to add TextColor and TextColorPressed properties, these might be useful in other use cases).

Tested on Windows 10, no regressions found.